### PR TITLE
FEAT: Added dedicated docker image tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### JHOVE-REST container
 In order to start the JHOVE REST container, use the following command
-> docker run --rm -p 8080:8080 openpreserve/jhove-rest
+> docker run --rm -p 8080:8080 openpreserve/jhove-rest:soc
 
 This starts the container and exposes the server inside the container to port 8080.
 In order to change the exposed port, change the number before the ':', ex. 5000:8080 to expose to port 5000.


### PR DESCRIPTION
There's a dedicated docker tag `soc` for Summer of Code developments, e.g. `openpreserve/jhove-rest:soc` and I've added details to the `README`.